### PR TITLE
HFP-4338 Remove sourceMap option from TerserWebpackPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,6 @@ module.exports = {
 	optimization: {
 		minimizer: [
 			new TerserWebpackPlugin( {
-				sourceMap: true,
 				terserOptions: {
 					output: {
 						// Preserve CKEditor 5 license comments.


### PR DESCRIPTION
When merged in, will remove the sourceMap option from TerserWebpackPlugin as `sourceMap` is not a valid option (anymore) and breaks building the library.